### PR TITLE
Fix defer-in-loop mutex bug in manipulateHTMLFiles

### DIFF
--- a/cmds/htmlassets/htmlassets.go
+++ b/cmds/htmlassets/htmlassets.go
@@ -230,8 +230,9 @@ func (c *client) manipulateHTMLFiles(assets []assetmanagerLocalAsset, manager as
 	for _, htmlAsset := range assets {
 		if err := sem.Acquire(ctx, 1); err != nil {
 			errMu.Lock()
-			defer errMu.Unlock()
 			errs = append(errs, fmt.Errorf("%w %q: %v", errManipulate, htmlAsset.Path(), err))
+			errMu.Unlock()
+			continue
 		}
 
 		go func(htmlAsset assetmanagerLocalAsset) {


### PR DESCRIPTION
## Summary
`errMu.Lock()` was paired with `defer errMu.Unlock()` directly in the outer for-loop body (not inside a function), so the unlock was deferred to when `manipulateHTMLFiles` returns, not to the end of that loop iteration. A second `sem.Acquire` failure in the same run would deadlock on the already-held lock.

Worse, the loop fell through to launch the goroutine even when `sem.Acquire` failed, and that goroutine unconditionally deferred `sem.Release(1)` - releasing a semaphore slot that was never successfully acquired for this asset, corrupting the weighted semaphore's internal accounting.

Now unlocks immediately and continues to the next asset on an acquire failure, without launching a goroutine for it.

This path is only reachable if `sem.Acquire`'s context is cancelled or deadlined, and the surrounding code always passes `context.Background()`, so it's presently unreachable - a landmine rather than an active bug. Not adding a dedicated regression test: reliably forcing the failure path would require making the hardcoded `maxWorkers=24` pool size injectable too, which is a larger change than this fix warrants - the existing `manipulateHTMLFiles`/`manipulations` test coverage confirms the success path is unaffected.

## Test plan
- [x] `go test ./...` passes (no behavior change on the success path)