### PR TITLE
Fix typos and minor consistency issues

### DIFF
--- a/cmds/genimgs/genimgs.go
+++ b/cmds/genimgs/genimgs.go
@@ -181,6 +181,13 @@ func (c *client) run(ctx context.Context) error {
 		return err
 	}
 
+	// Left disabled: toDelete is a list of stale S3 object keys (see
+	// assessAssets below), but deleteImages operates on local filesystem
+	// paths (os.Remove, filepath.Dir), not S3 objects. Uncommenting this
+	// as-is would not clean up stale S3 images - it would call os.Remove
+	// on S3 key strings as if they were local paths. Deleting objects
+	// from a production S3 bucket deserves a deliberate, tested
+	// implementation of its own rather than just flipping this back on.
 	/* err = c.deleteImages(toDelete)
 	if err != nil {
 		return err
@@ -289,7 +296,7 @@ func (c *client) createImages(imgs []generateImage) error {
 	}
 
 	if errCount > 0 {
-		return fmt.Errorf("%v errors occured while creating images", errCount)
+		return fmt.Errorf("%v errors occurred while creating images", errCount)
 	}
 
 	return nil
@@ -479,7 +486,7 @@ func createImage(img generateImage) error {
 	case ".avif":
 		return createAvifImage(img)
 	default:
-		return fmt.Errorf("unsupported file: %q with extension%q", img.outputPath, ext)
+		return fmt.Errorf("unsupported file: %q with extension %q", img.outputPath, ext)
 	}
 }
 

--- a/embedassets/embedassets.go
+++ b/embedassets/embedassets.go
@@ -50,7 +50,7 @@ func CopyAssets(staticDir string) ([]string, error) {
 			}
 
 			fp := path.Join(outputDir, currentDir, d.Name())
-			err = os.WriteFile(fp, data, 0755)
+			err = os.WriteFile(fp, data, 0644)
 			if err != nil {
 				return nil, fmt.Errorf("%w: %v", errWriteFailed, err)
 			}

--- a/utils/css/css.go
+++ b/utils/css/css.go
@@ -62,7 +62,7 @@ func WithType(t CSSType) FormatOption {
 	}
 }
 
-func WithNamspace(s string) FormatOption {
+func WithNamespace(s string) FormatOption {
 	return func(o *formationOption) {
 		o.namespace = s
 	}

--- a/utils/css/css_test.go
+++ b/utils/css/css_test.go
@@ -41,7 +41,7 @@ func Test_Format(t *testing.T) {
 			typ:         LayoutType,
 			body:        "example-body",
 			opts: []FormatOption{
-				WithNamspace("example-namespace"),
+				WithNamespace("example-namespace"),
 			},
 			want: `n-example-namespace-l-example-body`,
 		},
@@ -50,7 +50,7 @@ func Test_Format(t *testing.T) {
 			typ:         UtilityType,
 			body:        "example-body",
 			opts: []FormatOption{
-				WithNamspace(""),
+				WithNamespace(""),
 				WithElement("example-element"),
 			},
 			want: `u-example-body__example-element`,
@@ -60,7 +60,7 @@ func Test_Format(t *testing.T) {
 			typ:         UtilityType,
 			body:        "example-body",
 			opts: []FormatOption{
-				WithNamspace(""),
+				WithNamespace(""),
 				WithModifier("example-modifier"),
 			},
 			want: `u-example-body--example-modifier`,
@@ -70,7 +70,7 @@ func Test_Format(t *testing.T) {
 			typ:         ComponentType,
 			body:        "example-body",
 			opts: []FormatOption{
-				WithNamspace("example-namespace"),
+				WithNamespace("example-namespace"),
 				WithElement("example-element"),
 				WithModifier("example-modifier"),
 			},


### PR DESCRIPTION
## Summary
- `utils/css`: rename exported `WithNamspace` -> `WithNamespace` (typo). Only referenced within this package and its own tests, so no other call sites needed updating.
- `cmds/genimgs`: "occured" -> "occurred", and a missing space in `"with extension%q"` -> `"with extension %q"`.
- `embedassets`: copied static assets (CSS/JS/images) were written with mode `0755` (executable), inconsistent with `cmds/htmlassets`'s `0644` for rendered HTML. These are never executed, so `0644` matches. The `0755` on the sibling `MkdirAll` call is unrelated and correct (directories need the execute bit to be traversable).
- Documents (without changing behavior) that the disabled S3 stale-image cleanup in genimgs is more than just dead code: `toDelete` is a list of S3 object keys, but `deleteImages` operates on local filesystem paths, so uncommenting the call as-is would not do what the surrounding code implies. Left disabled per discussion - deleting objects from a production S3 bucket deserves a deliberate, tested implementation of its own.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass