### PR TITLE
Migrate genimgs S3 upload from feature/s3/manager to transfermanager

### DIFF
--- a/cmds/genimgs/genimgs.go
+++ b/cmds/genimgs/genimgs.go
@@ -34,7 +34,8 @@ import (
 	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	transfermanager "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	transfermanagertypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -83,7 +84,7 @@ type client struct {
 	staticManager    *assetmanager.Manager
 	generatedManager *assetmanager.Manager
 	s3               *s3.Client
-	s3Manager        *s3manager.Uploader
+	s3Manager        *transfermanager.Client
 	s3Sem            *semaphore.Weighted
 }
 
@@ -128,7 +129,7 @@ func newClient(ctx context.Context) (*client, error) {
 	}
 
 	s3Client := s3.NewFromConfig(cfg)
-	s3Manager := s3manager.NewUploader(s3Client)
+	s3Manager := transfermanager.New(s3Client)
 
 	return &client{
 		staticdir:        c.GenAssets.StaticDir,
@@ -514,9 +515,9 @@ func (c *client) uploadImage(ctx context.Context, img generateImage) error {
 
 	cc := cacheControlHeader(*cacheControlAge)
 
-	_, err = c.s3Manager.Upload(ctx, &s3.PutObjectInput{
+	_, err = c.s3Manager.UploadObject(ctx, &transfermanager.UploadObjectInput{
 		Bucket:       &c.s3Bucket,
-		ACL:          awstypes.ObjectCannedACLPublicRead,
+		ACL:          transfermanagertypes.ObjectCannedACLPublicRead,
 		CacheControl: &cc,
 		Key:          &key,
 		Body:         f,

--- a/cmds/genimgs/upload_test.go
+++ b/cmds/genimgs/upload_test.go
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/sync/semaphore"
+)
+
+// fakeS3APIClient implements transfermanager.S3APIClient. Only PutObject is
+// expected to be called for the small test files uploaded here; the other
+// methods exist purely to satisfy the interface.
+type fakeS3APIClient struct {
+	putObjectCalls []*s3.PutObjectInput
+	putObjectErr   error
+}
+
+func (f *fakeS3APIClient) PutObject(ctx context.Context, in *s3.PutObjectInput, opts ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	f.putObjectCalls = append(f.putObjectCalls, in)
+	return &s3.PutObjectOutput{}, f.putObjectErr
+}
+
+func (f *fakeS3APIClient) UploadPart(ctx context.Context, in *s3.UploadPartInput, opts ...func(*s3.Options)) (*s3.UploadPartOutput, error) {
+	return nil, errors.New("UploadPart: not implemented by fake")
+}
+
+func (f *fakeS3APIClient) CreateMultipartUpload(ctx context.Context, in *s3.CreateMultipartUploadInput, opts ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error) {
+	return nil, errors.New("CreateMultipartUpload: not implemented by fake")
+}
+
+func (f *fakeS3APIClient) CompleteMultipartUpload(ctx context.Context, in *s3.CompleteMultipartUploadInput, opts ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error) {
+	return nil, errors.New("CompleteMultipartUpload: not implemented by fake")
+}
+
+func (f *fakeS3APIClient) AbortMultipartUpload(ctx context.Context, in *s3.AbortMultipartUploadInput, opts ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error) {
+	return nil, errors.New("AbortMultipartUpload: not implemented by fake")
+}
+
+func (f *fakeS3APIClient) GetObject(ctx context.Context, in *s3.GetObjectInput, opts ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return nil, errors.New("GetObject: not implemented by fake")
+}
+
+func (f *fakeS3APIClient) HeadObject(ctx context.Context, in *s3.HeadObjectInput, opts ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	return nil, errors.New("HeadObject: not implemented by fake")
+}
+
+func (f *fakeS3APIClient) ListObjectsV2(ctx context.Context, in *s3.ListObjectsV2Input, opts ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	return nil, errors.New("ListObjectsV2: not implemented by fake")
+}
+
+func Test_uploadImage(t *testing.T) {
+	t.Run("uploads the file with the resolved cache-control header and S3 key", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "static", "img", "a.webp")
+		if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+			t.Fatalf("Failed to set up test: %v", err)
+		}
+		if err := os.WriteFile(outputPath, []byte("fake image bytes"), 0644); err != nil {
+			t.Fatalf("Failed to set up test: %v", err)
+		}
+
+		fake := &fakeS3APIClient{}
+		c := &client{
+			staticdir: filepath.Join(dir, "static") + string(filepath.Separator),
+			s3Bucket:  "example-bucket",
+			s3Manager: transfermanager.New(fake),
+			s3Sem:     semaphore.NewWeighted(1),
+		}
+
+		if err := c.uploadImage(context.Background(), generateImage{outputPath: outputPath}); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if len(fake.putObjectCalls) != 1 {
+			t.Fatalf("Expected exactly one PutObject call, got %v", len(fake.putObjectCalls))
+		}
+
+		got := fake.putObjectCalls[0]
+		if got.Bucket == nil || *got.Bucket != "example-bucket" {
+			t.Fatalf("Unexpected bucket: %v", got.Bucket)
+		}
+		if got.Key == nil || *got.Key != "img/a.webp" {
+			t.Fatalf("Unexpected key: %v", got.Key)
+		}
+		wantCacheControl := cacheControlHeader(*cacheControlAge)
+		if got.CacheControl == nil || *got.CacheControl != wantCacheControl {
+			t.Fatalf("Unexpected Cache-Control header; got %v, want %v", got.CacheControl, wantCacheControl)
+		}
+	})
+
+	t.Run("returns an error if the upload fails", func(t *testing.T) {
+		dir := t.TempDir()
+		outputPath := filepath.Join(dir, "a.webp")
+		if err := os.WriteFile(outputPath, []byte("fake image bytes"), 0644); err != nil {
+			t.Fatalf("Failed to set up test: %v", err)
+		}
+
+		errInjected := errors.New("injected upload error")
+		fake := &fakeS3APIClient{putObjectErr: errInjected}
+		c := &client{
+			staticdir: dir + string(filepath.Separator),
+			s3Bucket:  "example-bucket",
+			s3Manager: transfermanager.New(fake),
+			s3Sem:     semaphore.NewWeighted(1),
+		}
+
+		err := c.uploadImage(context.Background(), generateImage{outputPath: outputPath})
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("Unexpected error; got %v, want %v", err, errInjected)
+		}
+	})
+
+	t.Run("returns an error if the file cannot be opened", func(t *testing.T) {
+		fake := &fakeS3APIClient{}
+		c := &client{
+			s3Manager: transfermanager.New(fake),
+			s3Sem:     semaphore.NewWeighted(1),
+		}
+
+		err := c.uploadImage(context.Background(), generateImage{outputPath: "/does/not/exist.webp"})
+		if err == nil {
+			t.Fatalf("Expected an error, got nil")
+		}
+		if len(fake.putObjectCalls) != 0 {
+			t.Fatalf("Expected no PutObject calls, got %v", len(fake.putObjectCalls))
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.30
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.2.13
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.2
 	github.com/chai2010/webp v1.4.0
 	github.com/disintegration/imaging v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.26 h1:Si8kk1kyJnuJWCEgiwpBtTdtgSd
 github.com/aws/aws-sdk-go-v2/credentials v1.19.26/go.mod h1:lBckz+W9SAdNtSDw3pYgQUJDJFcBBWry0GSzw+bK0TY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30 h1:/hi1JADLEW9YYryEz1w4GQu0EtP23pP553Cf9KgsDV4=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30/go.mod h1:/3AOgy4K17Dm4ucMZVC/MJkzy5kmfKUcINRHZyo0koQ=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.30 h1:qzaF2qXmjqBcLbtcpIxOddoDH5eKIRdmOiKt7BatgDc=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.30/go.mod h1:5LlJNctj1Y7l59FPonG4LNjK5DvorTKIS+pAVuWAh3s=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.2.13 h1:zHi0z+ZT207/QPyaCmTr4JksQ0Ty0DM+WXW0xsfckXQ=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.2.13/go.mod h1:ycxBs1ztF7RbxNWiJoIegPCvsfuO7dCvtyyloQvRgNs=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 h1:xM/Is9cKMHa8Jj8zkvWhvrFkZsXJV9E+BB4g0HW0duQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30/go.mod h1:WueJeNDZvK1fMYEWJIkcivBfEzUkTpBhzlrUKKY8EuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 h1:jn46zC9LdsVR/ZpMIJqMqb8hHv31BlLx3ulVqNspUOk=


### PR DESCRIPTION
## Summary
`feature/s3/manager` is upstream-deprecated by AWS in favor of `feature/s3/transfermanager` (see its own go.mod: `"Deprecated: superceded by feature/s3/transfermanager"`, https://github.com/aws/aws-sdk-go-v2/discussions/3306), even though the pinned version is otherwise current.

The new client's `UploadObject` API is a close match for the old `Uploader.Upload`: same Bucket/Key/Body/ACL/CacheControl fields on the input struct. The one difference is that transfermanager's `ObjectCannedACL` lives in its own `feature/s3/transfermanager/types` package rather than `service/s3/types`.

Adds tests for `uploadImage` using a fake `S3APIClient` (`transfermanager.New` accepts any implementation of that interface, not just a real `*s3.Client`), covering: the bucket/key/Cache-Control header sent on a successful upload, the upload-failure error path, and the file-open failure path. The successful-upload test also doubles as end-to-end confirmation that the Cache-Control pointer fix from earlier in this stack (#748) is correctly applied through the new client.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] New `uploadImage` tests cover success, upload failure, and file-open failure