### PR TITLE
Add panic recovery around image decoding

### DIFF
--- a/cmds/genimgs/genimgs.go
+++ b/cmds/genimgs/genimgs.go
@@ -59,6 +59,8 @@ var (
 	configPath      = flag.String("config", "asset-manager.json", "The path of the Config file.")
 	cacheControlAge = flag.Int64("cache_control", 31104000, "The max age for caching images")
 	homedirExpand   = homedir.Expand
+
+	imagingOpen = imaging.Open
 )
 
 func main() {
@@ -383,8 +385,21 @@ func (c *client) generateImageList(imgs []assetmanager.Asset) ([]generateImage, 
 	return genImgs, nil
 }
 
+// safeOpenImage wraps imagingOpen with a panic recovery, since
+// disintegration/imaging has a known, unpatched panic-on-crafted-TIFF bug
+// (CVE-2023-36308) and Go's image decoders can panic on other malformed
+// input too. Turns a crash of the whole batch run into a per-image error.
+func safeOpenImage(path string) (img image.Image, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic while decoding image %q: %v", path, r)
+		}
+	}()
+	return imagingOpen(path)
+}
+
 func (c *client) generateImageSet(imgPath string) ([]generateImage, error) {
-	srcImg, err := imaging.Open(imgPath)
+	srcImg, err := safeOpenImage(imgPath)
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +541,7 @@ func (c *client) uploadImage(ctx context.Context, img generateImage) error {
 }
 
 func createImagingImage(img generateImage) error {
-	srcImg, err := imaging.Open(img.originalPath)
+	srcImg, err := safeOpenImage(img.originalPath)
 	if err != nil {
 		return err
 	}
@@ -540,7 +555,7 @@ func createImagingImage(img generateImage) error {
 }
 
 func createWebpImage(img generateImage) error {
-	srcImg, err := imaging.Open(img.originalPath)
+	srcImg, err := safeOpenImage(img.originalPath)
 	if err != nil {
 		return err
 	}

--- a/cmds/genimgs/safe_open_test.go
+++ b/cmds/genimgs/safe_open_test.go
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package main
+
+import (
+	"errors"
+	"image"
+	"strings"
+	"testing"
+
+	"github.com/disintegration/imaging"
+)
+
+func Test_safeOpenImage(t *testing.T) {
+	origImagingOpen := imagingOpen
+	defer func() { imagingOpen = origImagingOpen }()
+
+	t.Run("returns the image on success", func(t *testing.T) {
+		want := image.NewRGBA(image.Rect(0, 0, 1, 1))
+		imagingOpen = func(path string, opts ...imaging.DecodeOption) (image.Image, error) {
+			return want, nil
+		}
+
+		got, err := safeOpenImage("example.png")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if got != image.Image(want) {
+			t.Fatalf("Unexpected image returned")
+		}
+	})
+
+	t.Run("returns the underlying error without a panic", func(t *testing.T) {
+		errInjected := errors.New("injected error")
+		imagingOpen = func(path string, opts ...imaging.DecodeOption) (image.Image, error) {
+			return nil, errInjected
+		}
+
+		_, err := safeOpenImage("example.png")
+		if !errors.Is(err, errInjected) {
+			t.Fatalf("Unexpected error; got %v, want %v", err, errInjected)
+		}
+	})
+
+	t.Run("recovers a panic and returns it as an error instead", func(t *testing.T) {
+		// This is the shape of failure disintegration/imaging has an
+		// unpatched CVE for (CVE-2023-36308: panic on a crafted TIFF file),
+		// so a single malformed image must not crash the whole batch run.
+		imagingOpen = func(path string, opts ...imaging.DecodeOption) (image.Image, error) {
+			panic("index out of range")
+		}
+
+		err := func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("safeOpenImage should have recovered the panic itself, got: %v", r)
+				}
+			}()
+			_, err = safeOpenImage("example.tiff")
+			return err
+		}()
+
+		if err == nil {
+			t.Fatalf("Expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "example.tiff") {
+			t.Fatalf("Expected error to mention the file path; got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Response to Dependabot alert #15: `disintegration/imaging` has an unpatched CVE (CVE-2023-36308: a crafted TIFF file causes an index-out-of-range panic in `Grayscale()` during scanning) with no fixed version available upstream. `imaging.Open()` sniffs format from file content rather than trusting the extension, so this isn't limited to files literally named `*.tiff`.

The realistic attack surface for this tool is the site owner's own local static asset directory, not public/untrusted uploads, so this isn't remotely exploitable in normal usage - but a single malformed or corrupt image file (this CVE or otherwise; Go's image decoders can panic on other malformed input too) would still crash the entire `genimgs` batch run today, taking down every other image being processed alongside it.

Wraps all three `imaging.Open` call sites (`generateImageSet`, `createImagingImage`, `createWebpImage`) with a new `safeOpenImage()` helper that recovers any panic during decode and returns it as a per-image error instead, via an injectable `imagingOpen` var (matching this codebase's existing pattern for testable package-level function vars, e.g. `osRename` in `revisionassets`).

Doesn't fix the upstream bug or dismiss the Dependabot alert - happy to dismiss #15 once this merges, since there's no version bump to point it at.

## Test plan
- [x] New tests inject a deliberately panicking stub via `imagingOpen` to prove the recovery actually works, not just that the code compiles
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass